### PR TITLE
Remove TODO references from eqn makefiles

### DIFF
--- a/releases/usr/src/cmd/eqn/makefile
+++ b/releases/usr/src/cmd/eqn/makefile
@@ -32,7 +32,7 @@ e.def:	e.y
 $(FILES):	e.h e.def
 
 list:
-	pr TODO $(SOURCE) makefile
+#      pr TODO $(SOURCE) makefile
 
 gcos:	y.tab.c
 	fsend e.h e.y *.c

--- a/releases/usr/src/cmd/neqn/makefile
+++ b/releases/usr/src/cmd/neqn/makefile
@@ -32,7 +32,7 @@ e.def:	e.y
 $(FILES):	e.h e.def
 
 list:
-	pr TODO $(SOURCE) makefile
+#      pr TODO $(SOURCE) makefile
 
 gcos:	y.tab.c
 	fsend e.h e.y *.c


### PR DESCRIPTION
## Summary
- comment out obsolete TODO references in eqn and neqn makefiles

## Testing
- `git status --short`