### PR TITLE
Use symlink for sys.s and fix setup

### DIFF
--- a/bcplkit-0.9.7/INSTALL
+++ b/bcplkit-0.9.7/INSTALL
@@ -25,10 +25,10 @@ followed by (as root)
 
     ./makeall install
 
-Otherwise, change to the "src" directory.  Check that the "sys.s"
-symbolic link points to "sys_linux64.s" on 64-bit Linux systems, or to
-"sys_linux.s" or "sys_freebsd.s" as
-appropriate for your system.  Enter
+Otherwise, change to the "src" directory.  The "makeall" script will
+create or replace the "sys.s" link as needed.  It should point to
+"sys_linux64.s" on 64-bit Linux systems, or to "sys_linux.s" or
+"sys_freebsd.s" as appropriate for your system.  Enter
 
     make
 

--- a/bcplkit-0.9.7/doc/porting-to-64bit.md
+++ b/bcplkit-0.9.7/doc/porting-to-64bit.md
@@ -8,8 +8,10 @@ work to operate correctly on 64-bit systems.
 
 To build the experimental 64-bit version:
 
-1. Ensure `src/sys.s` links to `sys_linux64.s`.
-2. Run `./makeall` or `make` within the `src` directory.
+1. Run `./makeall` to create the `src/sys.s` link to `sys_linux64.s` if
+   needed.
+2. Alternatively run `make` within the `src` directory once the link is
+   in place.
 
 Further testing and runtime adjustments are likely required before the
 compiler can fully operate in a native 64-bit environment.

--- a/bcplkit-0.9.7/makeall
+++ b/bcplkit-0.9.7/makeall
@@ -16,6 +16,11 @@ if test -z "$1"; then
 fi
 
 # Configure
+# Replace an existing regular file with the correct symbolic link
+if [ -e src/sys.s ] && [ ! -h src/sys.s ]; then
+    echo "Replacing stale sys.s"
+    rm -f src/sys.s
+fi
 if test -e src/sys.s; then
     :
 else


### PR DESCRIPTION
## Summary
- make `src/sys.s` a symbolic link
- handle old regular `sys.s` files in `makeall`
- update INSTALL and porting docs accordingly

## Testing
- `git status --short`