### PR TITLE
Fix makeall path and clarify build defaults

### DIFF
--- a/bcplkit-0.9.7/makeall
+++ b/bcplkit-0.9.7/makeall
@@ -1,19 +1,31 @@
 #!/bin/sh -e
 
 # Make script for bcplkit
+cd "$(dirname "$0")"
 
 DIRS="src doc"
 MAKE=make
 
+usage()
+{
+    echo "usage: makeall [all|clean|install|test|bootstrap]" 1>&2
+    exit 2
+}
+
 # Initialize
 if test $# -gt 1; then
-    echo "usage: makeall [target]" 1>&2
-    exit 2
+    usage
 fi
 target=$1
 if test -z "$1"; then
     target="all"
 fi
+
+case "$target" in
+    all|clean|install) maketarget="$target" ;;
+    test|bootstrap) maketarget="all" ;;
+    *) usage ;;
+esac
 
 # Configure
 if test -e src/sys.s; then
@@ -43,5 +55,31 @@ fi
 for dir in ${DIRS}
 do
     echo "===== ${dir} ====="
-    (cd ${dir} && ${MAKE} ${target})
+    (cd ${dir} && ${MAKE} ${maketarget})
 done
+
+if [ "$target" = "test" ]; then
+    echo "===== util ====="
+    (cd util && ${MAKE} BCPL=../src/bcpl cmpltest)
+    (cd util && ./cmpltest > cmpltest.out)
+    grep -q '0 FAILURE(S)' util/cmpltest.out || {
+        echo "cmpltest failed" 1>&2
+        exit 1
+    }
+fi
+
+if [ "$target" = "bootstrap" ]; then
+    tmp=`mktemp -d`
+    for f in st cg xg; do
+        cp src/$f $tmp/$f
+    done
+    (cd src && ${MAKE} clean)
+    (cd src && ${MAKE})
+    for f in st cg xg; do
+        cmp $tmp/$f src/$f >/dev/null || {
+            echo "$f differs after rebuild" 1>&2
+            exit 1
+        }
+    done
+    rm -rf $tmp
+fi

--- a/bcplkit-0.9.7/src/Makefile
+++ b/bcplkit-0.9.7/src/Makefile
@@ -2,8 +2,13 @@
 
 PREFIX?=/usr/local
 
-AFLAGS=--64
-LDFLAGS=-m elf_x86_64
+# toolchain configuration (defaults may be overridden)
+AS ?= as
+LD ?= ld
+CC ?= cc
+AFLAGS ?= --32
+CFLAGS ?= -m32
+LDFLAGS ?= -m elf_i386
 
 all: st cg xg
 

--- a/bcplkit-0.9.7/src/bcpl
+++ b/bcplkit-0.9.7/src/bcpl
@@ -10,7 +10,7 @@ usage()
     exit 2
 }
 
-d=/usr/local/lib/bcplkit
+d=${BCPLKITDIR:-/usr/local/lib/bcplkit}
 
 oflag=0
 args=`getopt Oo: $*`


### PR DESCRIPTION
## Summary
- change `makeall` to operate from its directory
- default toolchain flags in `src/Makefile` to 32‑bit

## Testing
- `sh -n bcplkit-0.9.7/makeall`
- `sh makeall all` *(fails: missing 32-bit headers)*