### PR TITLE
Add register aliases for 32/64-bit assembly

### DIFF
--- a/bcplkit-0.9.7/src/Makefile
+++ b/bcplkit-0.9.7/src/Makefile
@@ -16,6 +16,9 @@ BINDIR ?= $(OBJDIR)
 
 CFLAGS += -m$(ARCHBITS) -std=c23
 AFLAGS += --$(ARCHBITS)
+ifeq ($(ARCHBITS),64)
+AFLAGS += --defsym X86_64=1
+endif
 LDFLAGS += -m $(if $(filter 64,$(ARCHBITS)),elf_x86_64,elf_i386)
 
 O := $(OBJDIR)

--- a/bcplkit-0.9.7/src/regs.inc
+++ b/bcplkit-0.9.7/src/regs.inc
@@ -1,0 +1,21 @@
+/* Register aliases for x86 architectures */
+
+.ifdef X86_64
+    .set RA, %rax
+    .set RB, %rbx
+    .set RC, %rcx
+    .set RD, %rdx
+    .set RSI, %rsi
+    .set RDI, %rdi
+    .set RBP, %rbp
+    .set RSP, %rsp
+.else
+    .set RA, %eax
+    .set RB, %ebx
+    .set RC, %ecx
+    .set RD, %edx
+    .set RSI, %esi
+    .set RDI, %edi
+    .set RBP, %ebp
+    .set RSP, %esp
+.endif

--- a/bcplkit-0.9.7/src/su.s
+++ b/bcplkit-0.9.7/src/su.s
@@ -2,6 +2,8 @@
 
 // $Id: su.s,v 1.7 2004/12/18 17:51:16 rn Exp $
 
+                .include "sys_defs.inc"
+
                 .set STACKBASE,54
                 .set STACKEND,55
                 .set STKSIZ,0x400000
@@ -12,60 +14,60 @@
 _start:         cld
 // Preserve initial stack pointer in RCX and create a small
 // temporary area on the stack for parsing the arguments.
-                mov %rsp,%rcx
-                sub $256,%rsp
-                mov %rsp,%rdi
-                inc %rdi
-                cmpl $2,(%rcx)
+                mov RSP,RC
+                sub $256,RSP
+                mov RSP,RDI
+                inc RDI
+                cmpl $2,(RC)
                 jb start.4
 //
-                lea 8(%rcx),%rbx
-                mov (%rbx),%rsi
+                lea 8(RC),RB
+                mov (RB),RSI
                 jmp start.3
 //
 start.1:        mov $' ',%al
-start.2:        cmp %rcx,%rdi
+start.2:        cmp RC,RDI
                 je start.4
                 stosb
 start.3:        lodsb
                 test %al,%al
                 jnz start.2
-                add $8,%rbx
-                mov (%rbx),%rsi
-                test %esi,%esi
+                add $8,RB
+                mov (RB),RSI
+                test RSI,RSI
                 jnz start.1
 //
-start.4:        mov %rdi,%rbx
-                sub %rsp,%rbx
-                dec %rbx
-                mov %bl,(%rsp,1)
+start.4:        mov RDI,RB
+                sub RSP,RB
+                dec RB
+                mov %bl,(RSP,1)
 //
-                sub %rdi,%rcx
-                and $7,%rcx
-                xor %eax,%eax
+                sub RDI,RC
+                and $7,RC
+                xor RA,RA
                 rep stosb
 //
                 call rtinit
                 push $STKSIZ
                 call sbrk
-                pop %rcx
+                pop RC
 //
-                mov $G,%rdi
-                mov %rax,%rbp
+                mov $G,RDI
+                mov RA,RBP
 //
-                shr $2,%eax
-                mov %eax,STACKBASE*4(%rdi)
-                add $STKSIZ>>2,%eax
-                mov %eax,STACKEND*4(%rdi)
+                shr $2,RA
+                mov RA,STACKBASE*4(RDI)
+                add $STKSIZ>>2,RA
+                mov RA,STACKEND*4(RDI)
 //
-                movl $0,(%rbp)
-                movl $finish,4(%rbp)
-                mov %rsp,%rax
-                shr $2,%rax
-                mov %eax,8(%rbp)
-                mov 4(%rdi),%eax
-                jmp *%rax
-finish:         xor %eax,%eax
-stop:           push %rax
+                movl $0,(RBP)
+                movl $finish,4(RBP)
+                mov RSP,RA
+                shr $2,RA
+                mov RA,8(RBP)
+                mov 4(RDI),RA
+                jmp *RA
+finish:         xor RA,RA
+stop:           push RA
                 call rtexit
                 call _exit

--- a/bcplkit-0.9.7/src/sys_defs.inc
+++ b/bcplkit-0.9.7/src/sys_defs.inc
@@ -1,0 +1,3 @@
+/* System-wide assembler definitions */
+
+.include "regs.inc"

--- a/bcplkit-0.9.7/src/sys_freebsd.s
+++ b/bcplkit-0.9.7/src/sys_freebsd.s
@@ -3,74 +3,76 @@
 // BCPL compiler runtime
 // System interface: FreeBSD
 
+                .include "sys_defs.inc"
+
                 .global _exit
-_exit:          mov $1,%eax
+_exit:          mov $1,RA
                 int $0x80
 
                 .global read
-read:           mov $3,%eax
+read:           mov $3,RA
                 int $0x80
                 jc error
                 ret
 
                 .global write
-write:          mov $4,%eax
+write:          mov $4,RA
                 int $0x80
                 jc error
                 ret
 
                 .global open
-open:           mov $5,%eax
+open:           mov $5,RA
                 int $0x80
                 jc error
                 ret
 
                 .global close
-close:          mov $6,%eax
+close:          mov $6,RA
                 int $0x80
                 jc error
                 ret
 
                 .global olseek
-olseek:         mov $0x13,%eax
+olseek:         mov $0x13,RA
                 int $0x80
                 jc error
                 ret
 
                 .global sbrk
-sbrk:           mov 4(%esp),%ecx
-                mov curbrk,%eax
-                add %eax,4(%esp)
-                mov $17,%eax
+sbrk:           mov 4(RSP),RC
+                mov curbrk,RA
+                add RA,4(RSP)
+                mov $17,RA
                 int $0x80
                 jc error
-                mov curbrk,%eax
-                add %ecx,curbrk
+                mov curbrk,RA
+                add RC,curbrk
                 ret
 
                 .global ioctl
-ioctl:          mov $0x36,%eax
+ioctl:          mov $0x36,RA
                 int $0x80
                 jc error
                 ret
 
-error:          mov %eax,errno
-                mov $-1,%eax
+error:          mov RA,errno
+                mov $-1,RA
                 ret
 
                 .set TERMIOSZ,0x40
                 .set TIOCGETA,0x402c7413
 
                 .global isatty
-isatty:         sub $TERMIOSZ,%esp
-                push %esp
+isatty:         sub $TERMIOSZ,RSP
+                push RSP
                 push $TIOCGETA
-                push 0xc+TERMIOSZ(%esp)
+                push 0xc+TERMIOSZ(RSP)
                 call ioctl
-                mov $0,%eax
+                mov $0,RA
                 jc isatty.1
-                inc %eax
-isatty.1:       add $0xc+TERMIOSZ,%esp
+                inc RA
+isatty.1:       add $0xc+TERMIOSZ,RSP
                 ret
 
                 .global oflags

--- a/bcplkit-0.9.7/src/sys_linux.s
+++ b/bcplkit-0.9.7/src/sys_linux.s
@@ -3,82 +3,84 @@
 // BCPL compiler runtime
 // System interface: Linux
 
+                .include "sys_defs.inc"
+
                 .global _exit
-_exit:          mov $1,%eax
+_exit:          mov $1,RA
                 jmp syscall
 
                 .global read
-read:           mov $3,%eax
+read:           mov $3,RA
                 jmp syscall
 
                 .global write
-write:          mov $4,%eax
+write:          mov $4,RA
                 jmp syscall
 
                 .global open
-open:           mov $5,%eax
+open:           mov $5,RA
                 jmp syscall
 
                 .global close
-close:          mov $6,%eax
+close:          mov $6,RA
                 jmp syscall
 
                 .global olseek
-olseek:         mov $0x13,%eax
+olseek:         mov $0x13,RA
                 jmp syscall
 
                 .global sbrk
-sbrk:           mov curbrk,%eax
-                test %eax,%eax
+sbrk:           mov curbrk,RA
+                test RA,RA
                 jnz 1f
                 call brk
-1:              push %eax
-                add 8(%esp),%eax
+1:              push RA
+                add 8(RSP),RA
                 call brk
-                pop %eax
+                pop RA
                 ret
 
-brk:            push %eax
-                mov $45,%eax
+brk:            push RA
+                mov $45,RA
                 call syscall
-                pop %ecx
-                mov %eax,curbrk
+                pop RC
+                mov RA,curbrk
                 ret
 
                 .global ioctl
-ioctl:          mov $0x36,%eax
+ioctl:          mov $0x36,RA
 
-syscall:        push %edx
-                push %ecx
-                push %ebx
-                mov 0x10(%esp),%ebx
-                mov 0x14(%esp),%ecx
-                mov 0x18(%esp),%edx
+syscall:        push RD
+                push RC
+                push RB
+                mov 0x10(RSP),RB
+                mov 0x14(RSP),RC
+                mov 0x18(RSP),RD
                 int $0x80
-                or %eax,%eax
+                or RA,RA
                 jge 1f
-                neg %eax
-                mov %eax,errno
-                mov $-1,%eax
+                neg RA
+                mov RA,errno
+                mov $-1,RA
                 stc
-1:              pop %ebx
-                pop %ecx
-                pop %edx
+1:              pop RB
+                pop RC
+                pop RD
                 ret
 
                 .set TERMIOSZ,0x40
                 .set TCGETS,0x5401
 
                 .global isatty
-isatty:         sub $TERMIOSZ,%esp
-                push %esp
+isatty:         sub $TERMIOSZ,RSP
+                push RSP
                 push $TCGETS
-                push 0xc+TERMIOSZ(%esp)
+                push 0xc+TERMIOSZ(RSP)
                 call ioctl
-                mov $0,%eax
+                mov $0,RA
                 jc isatty.1
-                inc %eax
-isatty.1:       add $0xc+TERMIOSZ,%esp
+                inc RA
+isatty.1:       add $0xc+TERMIOSZ,RSP
                 ret
 
                 .global oflags


### PR DESCRIPTION
## Summary
- provide `src/regs.inc` with register aliases for 32‑bit and 64‑bit x86
- include `regs.inc` from new `sys_defs.inc`
- use the new aliases in `sys_linux.s`, `sys_freebsd.s`, `rt.s`, and `su.s`
- mark 64‑bit builds with `X86_64` for the assembler

## Testing
- `BUILD_BITS=32 make build/32/sys.o build/32/rt.o build/32/su.o`
- `BUILD_BITS=64 make build/64/sys.o build/64/rt.o build/64/su.o`