### PR TITLE
Add syscall macro header and refactor assembly

### DIFF
--- a/bcplkit-0.9.7/doc/porting-to-64bit.md
+++ b/bcplkit-0.9.7/doc/porting-to-64bit.md
@@ -13,3 +13,13 @@ To build the experimental 64-bit version:
 
 Further testing and runtime adjustments are likely required before the
 compiler can fully operate in a native 64-bit environment.
+
+## System call interface notes
+
+Runtime assembly sources now include `sys_defs.inc`, which lists syscall
+numbers for Linux (i386 and x86-64) and FreeBSD along with register usage.
+These values were taken from the Linux syscall tables in the kernel source
+(`arch/x86/entry/syscalls/syscall_32.tbl` and `syscall_64.tbl`) and from the
+FreeBSD `sys/sys/syscall.h` header.  The 32‑bit routines continue to use the
+`int $0x80` calling convention, while the 64‑bit code follows the x86‑64
+`syscall` ABI with the `%rcx` argument copied to `%r10`.

--- a/bcplkit-0.9.7/src/sys_defs.inc
+++ b/bcplkit-0.9.7/src/sys_defs.inc
@@ -1,0 +1,41 @@
+// Common syscall numbers and register conventions
+// References:
+//  - Linux i386 system calls: arch/x86/entry/syscalls/syscall_32.tbl
+//  - Linux x86-64 system calls: arch/x86/entry/syscalls/syscall_64.tbl
+//  - FreeBSD i386 system calls: sys/sys/syscall.h
+
+/* Linux i386 syscall numbers */
+.set SYS_EXIT_LINUX32,     1
+.set SYS_READ_LINUX32,     3
+.set SYS_WRITE_LINUX32,    4
+.set SYS_OPEN_LINUX32,     5
+.set SYS_CLOSE_LINUX32,    6
+.set SYS_LSEEK_LINUX32,    0x13
+.set SYS_BRK_LINUX32,      45
+.set SYS_IOCTL_LINUX32,    0x36
+
+/* Linux x86-64 syscall numbers */
+.set SYS_EXIT_LINUX64,     60
+.set SYS_READ_LINUX64,     0
+.set SYS_WRITE_LINUX64,    1
+.set SYS_OPEN_LINUX64,     2
+.set SYS_CLOSE_LINUX64,    3
+.set SYS_LSEEK_LINUX64,    8
+.set SYS_BRK_LINUX64,      12
+.set SYS_IOCTL_LINUX64,    16
+
+/* FreeBSD i386 syscall numbers */
+.set SYS_EXIT_FREEBSD,     1
+.set SYS_READ_FREEBSD,     3
+.set SYS_WRITE_FREEBSD,    4
+.set SYS_OPEN_FREEBSD,     5
+.set SYS_CLOSE_FREEBSD,    6
+.set SYS_LSEEK_FREEBSD,    0x13
+.set SYS_SBRK_FREEBSD,     17
+.set SYS_IOCTL_FREEBSD,    0x36
+
+/* Register conventions:
+ *  Linux i386:    eax=syscall#, ebx,ecx,edx as first three args
+ *  Linux x86-64:  rax=syscall#, rdi,rsi,rdx,r10,r8,r9 as args; rcx moved to r10
+ *  FreeBSD i386:  eax=syscall#, ebx,ecx,edx as args, int $0x80
+ */

--- a/bcplkit-0.9.7/src/sys_freebsd.s
+++ b/bcplkit-0.9.7/src/sys_freebsd.s
@@ -1,38 +1,41 @@
 // Copyright (c) 2004 Robert Nordier.  All rights reserved.
 
 // BCPL compiler runtime
-// System interface: FreeBSD
+// System interface: FreeBSD (i386)
+// Syscall numbers from FreeBSD sys/sys/syscall.h
+
+                .include "sys_defs.inc"
 
                 .global _exit
-_exit:          mov $1,%eax
+_exit:          mov $SYS_EXIT_FREEBSD,%eax
                 int $0x80
 
                 .global read
-read:           mov $3,%eax
+read:           mov $SYS_READ_FREEBSD,%eax
                 int $0x80
                 jc error
                 ret
 
                 .global write
-write:          mov $4,%eax
+write:          mov $SYS_WRITE_FREEBSD,%eax
                 int $0x80
                 jc error
                 ret
 
                 .global open
-open:           mov $5,%eax
+open:           mov $SYS_OPEN_FREEBSD,%eax
                 int $0x80
                 jc error
                 ret
 
                 .global close
-close:          mov $6,%eax
+close:          mov $SYS_CLOSE_FREEBSD,%eax
                 int $0x80
                 jc error
                 ret
 
                 .global olseek
-olseek:         mov $0x13,%eax
+olseek:         mov $SYS_LSEEK_FREEBSD,%eax
                 int $0x80
                 jc error
                 ret
@@ -41,7 +44,7 @@ olseek:         mov $0x13,%eax
 sbrk:           mov 4(%esp),%ecx
                 mov curbrk,%eax
                 add %eax,4(%esp)
-                mov $17,%eax
+                mov $SYS_SBRK_FREEBSD,%eax
                 int $0x80
                 jc error
                 mov curbrk,%eax
@@ -49,7 +52,7 @@ sbrk:           mov 4(%esp),%ecx
                 ret
 
                 .global ioctl
-ioctl:          mov $0x36,%eax
+ioctl:          mov $SYS_IOCTL_FREEBSD,%eax
                 int $0x80
                 jc error
                 ret

--- a/bcplkit-0.9.7/src/sys_linux.s
+++ b/bcplkit-0.9.7/src/sys_linux.s
@@ -1,30 +1,33 @@
 // Copyright (c) 2004 Robert Nordier.  All rights reserved.
 
 // BCPL compiler runtime
-// System interface: Linux
+// System interface: Linux (i386)
+// Syscall numbers from Linux arch/x86/entry/syscalls/syscall_32.tbl
+
+                .include "sys_defs.inc"
 
                 .global _exit
-_exit:          mov $1,%eax
+_exit:          mov $SYS_EXIT_LINUX32,%eax
                 jmp syscall
 
                 .global read
-read:           mov $3,%eax
+read:           mov $SYS_READ_LINUX32,%eax
                 jmp syscall
 
                 .global write
-write:          mov $4,%eax
+write:          mov $SYS_WRITE_LINUX32,%eax
                 jmp syscall
 
                 .global open
-open:           mov $5,%eax
+open:           mov $SYS_OPEN_LINUX32,%eax
                 jmp syscall
 
                 .global close
-close:          mov $6,%eax
+close:          mov $SYS_CLOSE_LINUX32,%eax
                 jmp syscall
 
                 .global olseek
-olseek:         mov $0x13,%eax
+olseek:         mov $SYS_LSEEK_LINUX32,%eax
                 jmp syscall
 
                 .global sbrk
@@ -39,14 +42,14 @@ sbrk:           mov curbrk,%eax
                 ret
 
 brk:            push %eax
-                mov $45,%eax
+                mov $SYS_BRK_LINUX32,%eax
                 call syscall
                 pop %ecx
                 mov %eax,curbrk
                 ret
 
                 .global ioctl
-ioctl:          mov $0x36,%eax
+ioctl:          mov $SYS_IOCTL_LINUX32,%eax
 
 syscall:        push %edx
                 push %ecx

--- a/bcplkit-0.9.7/src/sys_linux64.s
+++ b/bcplkit-0.9.7/src/sys_linux64.s
@@ -1,32 +1,35 @@
 // 64-bit Linux system interface for BCPL runtime
 // Derived from original 32-bit sys_linux.s
+// Syscall numbers from Linux arch/x86/entry/syscalls/syscall_64.tbl
+
+        .include "sys_defs.inc"
 
         .text
         .global _exit, read, write, open, close, olseek, sbrk, ioctl, isatty
         .global oflags, curbrk, errno
 
 _exit:
-        mov $60, %rax
+        mov $SYS_EXIT_LINUX64, %rax
         jmp syscall_common
 
 read:
-        mov $0, %rax
+        mov $SYS_READ_LINUX64, %rax
         jmp syscall_common
 
 write:
-        mov $1, %rax
+        mov $SYS_WRITE_LINUX64, %rax
         jmp syscall_common
 
 open:
-        mov $2, %rax
+        mov $SYS_OPEN_LINUX64, %rax
         jmp syscall_common
 
 close:
-        mov $3, %rax
+        mov $SYS_CLOSE_LINUX64, %rax
         jmp syscall_common
 
 olseek:
-        mov $8, %rax
+        mov $SYS_LSEEK_LINUX64, %rax
         jmp syscall_common
 
 sbrk:
@@ -43,13 +46,13 @@ sbrk:
 
 brk_call:
         mov %rax, %rdi
-        mov $12, %rax
+        mov $SYS_BRK_LINUX64, %rax
         syscall
         mov %rdi, curbrk(%rip)
         ret
 
 ioctl:
-        mov $16, %rax
+        mov $SYS_IOCTL_LINUX64, %rax
         jmp syscall_common
 
 syscall_common:


### PR DESCRIPTION
## Summary
- add `sys_defs.inc` header describing common syscalls and register usage
- refactor `sys_linux.s`, `sys_linux64.s` and `sys_freebsd.s` to use the new macros
- update 64-bit syscall code path and comments
- document syscall table references in `porting-to-64bit.md`

## Testing
- `make -C bcplkit-0.9.7/src` *(fails: operand size mismatch for `pop`)*