### PR TITLE
Add shared syscall macros for runtime assembly

### DIFF
--- a/bcplkit-0.9.7/doc/porting-to-64bit.md
+++ b/bcplkit-0.9.7/doc/porting-to-64bit.md
@@ -49,6 +49,11 @@ register name (`%eax`/`%rax`, `%ebx`/`%rbx`, and so on) according to the
 chosen word size.  These appear throughout `su.s` and the `sys_*` files
 and remove many hard coded register names.
 
+System call numbers are collected in `syscall_defs.inc`.  The values
+mirror those listed in the Linux `syscall_*.tbl` files and the FreeBSD
+`syscall.h` header.  Each `sys_*.s` file includes this header so the
+same symbolic names can be used for both 32‑bit and 64‑bit builds.
+
 ### Remaining 32‑bit assumptions
 
 The compiler and interpreter still define `WORDSIZE` as 32 and operate on

--- a/bcplkit-0.9.7/src/sys_defs.inc
+++ b/bcplkit-0.9.7/src/sys_defs.inc
@@ -1,3 +1,4 @@
 /* System-wide assembler definitions */
 
 .include "regs.inc"
+.include "syscall_defs.inc"

--- a/bcplkit-0.9.7/src/sys_freebsd.s
+++ b/bcplkit-0.9.7/src/sys_freebsd.s
@@ -1,40 +1,42 @@
 // Copyright (c) 2004 Robert Nordier.  All rights reserved.
 
 // BCPL compiler runtime
-// System interface: FreeBSD
+// System interface: FreeBSD (i386)
+// Numbers from sys/sys/syscall.h
+// Arguments are passed on the stack for int $0x80
 
                 .include "sys_defs.inc"
 
                 .global _exit
-_exit:          mov $1,RA
+_exit:          mov $FBSD32_EXIT,RA
                 int $0x80
 
                 .global read
-read:           mov $3,RA
+read:           mov $FBSD32_READ,RA
                 int $0x80
                 jc error
                 ret
 
                 .global write
-write:          mov $4,RA
+write:          mov $FBSD32_WRITE,RA
                 int $0x80
                 jc error
                 ret
 
                 .global open
-open:           mov $5,RA
+open:           mov $FBSD32_OPEN,RA
                 int $0x80
                 jc error
                 ret
 
                 .global close
-close:          mov $6,RA
+close:          mov $FBSD32_CLOSE,RA
                 int $0x80
                 jc error
                 ret
 
                 .global olseek
-olseek:         mov $0x13,RA
+olseek:         mov $FBSD32_LSEEK,RA
                 int $0x80
                 jc error
                 ret
@@ -43,7 +45,7 @@ olseek:         mov $0x13,RA
 sbrk:           mov 4(RSP),RC
                 mov curbrk,RA
                 add RA,4(RSP)
-                mov $17,RA
+                mov $FBSD32_BRK,RA
                 int $0x80
                 jc error
                 mov curbrk,RA
@@ -51,7 +53,7 @@ sbrk:           mov 4(RSP),RC
                 ret
 
                 .global ioctl
-ioctl:          mov $0x36,RA
+ioctl:          mov $FBSD32_IOCTL,RA
                 int $0x80
                 jc error
                 ret

--- a/bcplkit-0.9.7/src/sys_linux.s
+++ b/bcplkit-0.9.7/src/sys_linux.s
@@ -1,32 +1,34 @@
 // Copyright (c) 2004 Robert Nordier.  All rights reserved.
 
 // BCPL compiler runtime
-// System interface: Linux
+// System interface: Linux (i386)
+// Numbers from arch/x86/entry/syscalls/syscall_32.tbl
+// Uses the i386 int $0x80 calling convention
 
                 .include "sys_defs.inc"
 
                 .global _exit
-_exit:          mov $1,RA
+_exit:          mov $LINUX32_EXIT,RA
                 jmp syscall
 
                 .global read
-read:           mov $3,RA
+read:           mov $LINUX32_READ,RA
                 jmp syscall
 
                 .global write
-write:          mov $4,RA
+write:          mov $LINUX32_WRITE,RA
                 jmp syscall
 
                 .global open
-open:           mov $5,RA
+open:           mov $LINUX32_OPEN,RA
                 jmp syscall
 
                 .global close
-close:          mov $6,RA
+close:          mov $LINUX32_CLOSE,RA
                 jmp syscall
 
                 .global olseek
-olseek:         mov $0x13,RA
+olseek:         mov $LINUX32_LSEEK,RA
                 jmp syscall
 
                 .global sbrk
@@ -41,14 +43,14 @@ sbrk:           mov curbrk,RA
                 ret
 
 brk:            push RA
-                mov $45,RA
+                mov $LINUX32_BRK,RA
                 call syscall
                 pop RC
                 mov RA,curbrk
                 ret
 
                 .global ioctl
-ioctl:          mov $0x36,RA
+ioctl:          mov $LINUX32_IOCTL,RA
 
 syscall:        push RD
                 push RC

--- a/bcplkit-0.9.7/src/sys_linux64.s
+++ b/bcplkit-0.9.7/src/sys_linux64.s
@@ -1,32 +1,34 @@
 // 64-bit Linux system interface for BCPL runtime
 // Derived from original 32-bit sys_linux.s
+// Numbers from arch/x86/entry/syscalls/syscall_64.tbl
+// Uses the x86-64 syscall instruction and moves %rcx into %r10
 
         .text
         .global _exit, read, write, open, close, olseek, sbrk, ioctl, isatty
         .global oflags, curbrk, errno
 
 _exit:
-        mov $60, %rax
+        mov $LINUX64_EXIT, %rax
         jmp syscall_common
 
 read:
-        mov $0, %rax
+        mov $LINUX64_READ, %rax
         jmp syscall_common
 
 write:
-        mov $1, %rax
+        mov $LINUX64_WRITE, %rax
         jmp syscall_common
 
 open:
-        mov $2, %rax
+        mov $LINUX64_OPEN, %rax
         jmp syscall_common
 
 close:
-        mov $3, %rax
+        mov $LINUX64_CLOSE, %rax
         jmp syscall_common
 
 olseek:
-        mov $8, %rax
+        mov $LINUX64_LSEEK, %rax
         jmp syscall_common
 
 sbrk:
@@ -43,13 +45,13 @@ sbrk:
 
 brk_call:
         mov %rax, %rdi
-        mov $12, %rax
+        mov $LINUX64_BRK, %rax
         syscall
         mov %rdi, curbrk(%rip)
         ret
 
 ioctl:
-        mov $16, %rax
+        mov $LINUX64_IOCTL, %rax
         jmp syscall_common
 
 syscall_common:

--- a/bcplkit-0.9.7/src/syscall_defs.inc
+++ b/bcplkit-0.9.7/src/syscall_defs.inc
@@ -1,0 +1,42 @@
+/* Common syscall numbers and calling conventions
+ *
+ * References:
+ * - Linux: arch/x86/entry/syscalls/syscall_32.tbl and syscall_64.tbl
+ * - FreeBSD: sys/sys/syscall.h
+ */
+
+/* Linux 32-bit (i386) syscall numbers */
+.set LINUX32_EXIT,    1
+.set LINUX32_READ,    3
+.set LINUX32_WRITE,   4
+.set LINUX32_OPEN,    5
+.set LINUX32_CLOSE,   6
+.set LINUX32_LSEEK,   13
+.set LINUX32_BRK,     45
+.set LINUX32_IOCTL,   54
+
+/* Linux 64-bit syscall numbers */
+.set LINUX64_EXIT,    60
+.set LINUX64_READ,    0
+.set LINUX64_WRITE,   1
+.set LINUX64_OPEN,    2
+.set LINUX64_CLOSE,   3
+.set LINUX64_LSEEK,   8
+.set LINUX64_BRK,     12
+.set LINUX64_IOCTL,   16
+
+/* FreeBSD 32-bit syscall numbers */
+.set FBSD32_EXIT,     1
+.set FBSD32_READ,     3
+.set FBSD32_WRITE,    4
+.set FBSD32_OPEN,     5
+.set FBSD32_CLOSE,    6
+.set FBSD32_LSEEK,    0x13
+.set FBSD32_BRK,      17
+.set FBSD32_IOCTL,    0x36
+
+/* Register conventions
+ * Linux i386:   eax=number, ebx,ecx,edx,esi,edi,ebp = args 1..6
+ * Linux x86_64: rax=number, rdi,rsi,rdx,r10,r8,r9   = args 1..6
+ * FreeBSD i386: eax=number, args pushed on stack
+ */


### PR DESCRIPTION
## Summary
- document the new syscall macro include in the 64‑bit notes
- provide `syscall_defs.inc` with Linux/FreeBSD numbers and comments on ABIs
- include the new macros in `sys_defs.inc`
- refactor `sys_linux.s`, `sys_linux64.s`, and `sys_freebsd.s` to use the macros and document their ABI

## Testing
- `sh makeall` *(fails: "SYNTAX ERROR" during build)*