### PR TITLE
Add BCPL smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        bits: [32, 64]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential gcc-multilib g++-multilib
+      - name: Run tests
+        run: |
+          ./tests/build_and_compile.sh ${{ matrix.bits }}

--- a/README.txt
+++ b/README.txt
@@ -38,3 +38,9 @@ Further information
 
 See `bcplkit-0.9.7/doc/porting-to-64bit.md` for notes on experimental
 64-bit support.
+
+Testing
+-------
+Run `tests/run_tests.sh` to build the BCPL toolchain and compile a small
+program in both 32- and 64-bit modes. Continuous integration performs
+the same steps on GitHub Actions.

--- a/tests/build_and_compile.sh
+++ b/tests/build_and_compile.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+BITS=$1
+DIR=$(cd "$(dirname "$0")"/.. && pwd)
+cd "$DIR/bcplkit-0.9.7"
+make -C src clean
+BITS=$BITS sh makeall all
+BCPLKITDIR=src/build/$BITS ./src/bcpl "$DIR/tests/hello.b"

--- a/tests/hello.b
+++ b/tests/hello.b
@@ -1,0 +1,7 @@
+GET "LIBHDR"
+
+LET START() = VALOF
+$(
+    WRITEF("Hello, world!*N")
+    RESULTIS 0
+$)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+DIR=$(dirname "$0")
+"$DIR/build_and_compile.sh" 32
+"$DIR/build_and_compile.sh" 64


### PR DESCRIPTION
## Summary
- add smoke tests to compile a trivial BCPL program in 32- and 64-bit modes
- run the smoke tests in CI
- document how to run the tests

## Testing
- `bash tests/build_and_compile.sh 64` *(fails: Permission denied)*
- `bash tests/build_and_compile.sh 32` *(fails: missing header: bits/libc-header-start.h)*
- `bash tests/run_tests.sh` *(fails: missing header)*
