### PR TITLE
Improve 64‑bit porting docs

### DIFF
--- a/bcplkit-0.9.7/doc/porting-to-64bit.md
+++ b/bcplkit-0.9.7/doc/porting-to-64bit.md
@@ -11,9 +11,9 @@ fully‑functional 64‑bit environment.
 ### Building for 32‑ or 64‑bit
 
 Running `makeall` selects an interface file based on the host and then
-invokes `make` in each subdirectory.  It sets the `BUILD_BITS`
-environment variable which the Makefile uses to choose appropriate
-compiler and linker flags.  For example,
+invokes `make` in each subdirectory.  The build script honours a
+`BITS` variable which controls the word size of the resulting binaries
+and is passed through to each Makefile.  For example,
 
 To build the experimental 64-bit version set `BITS=64` when invoking
 `makeall` or `make`:
@@ -29,25 +29,30 @@ architecture).
 
 ```sh
 ./makeall            # build for the host (32‑bit default on x86‑64)
-BUILD_BITS=64 ./makeall   # force a 64‑bit build
-BUILD_BITS=32 ./makeall   # force a 32‑bit build
+BITS=64 ./makeall    # force a 64‑bit build
+BITS=32 ./makeall    # force a 32‑bit build
 ```
 
-`make` may also be run directly in `src` with `BUILD_BITS` set.  Object
-files are placed under `build/32` or `build/64` depending on the value of
-this variable.
+`make` may also be run directly in `src` with `BITS` set.  Object files
+are placed under `build/32` or `build/64` depending on the value of this
+variable.
 
 The helper file `src/sys.s` is a link to the appropriate system
 interface (`sys_linux.s`, `sys_linux64.s`, or `sys_freebsd.s`).
 
 ### Register macros
 
-The startup and system interface code now use small macros for the core
-registers so the same source can assemble for both 32‑bit and 64‑bit
-x86.  Macros such as `RA`, `RB`, `RC` and `SPREG` expand to the correct
-register name (`%eax`/`%rax`, `%ebx`/`%rbx`, and so on) according to the
-chosen word size.  These appear throughout `su.s` and the `sys_*` files
-and remove many hard coded register names.
+The startup and system interface code use small macros for the core
+registers so the same sources assemble for both 32‑bit and 64‑bit x86.
+The file `src/regs.inc` defines aliases such as:
+
+```
+RA RB RC RD RSI RDI RBP RSP
+```
+
+These expand to `%eax`..`%esp` for 32‑bit and `%rax`..`%rsp` for 64‑bit
+builds.  They appear throughout `su.s` and the `sys_*` files to avoid
+hard coded register names.
 
 ### Remaining 32‑bit assumptions
 
@@ -57,3 +62,6 @@ The compiler and interpreter still define `WORDSIZE` as 32 and operate on
 BCPL runtime and generated code continue to assume 32‑bit addresses.
 Further testing and refactoring are required before the compiler can
 fully operate in a native 64‑bit environment.
+In particular the heap manager, interpreter and generated code still
+address memory using 32‑bit offsets so large address spaces are not yet
+accessible.


### PR DESCRIPTION
## Summary
- document BITS variable used by makeall and Makefile
- clarify macro aliases for registers
- expand notes on remaining 32-bit assumptions

## Testing
- `make -C bcplkit-0.9.7/src BITS=64` *(fails: syntax errors)*
- `pre-commit run --files bcplkit-0.9.7/doc/porting-to-64bit.md` *(fails: command not found)*