### PR TITLE
Add register macros and use them

### DIFF
--- a/bcplkit-0.9.7/src/regs.inc
+++ b/bcplkit-0.9.7/src/regs.inc
@@ -1,4 +1,11 @@
-/* Register aliases for x86 architectures */
+/*
+ * Register aliases for x86 assemblers.
+ *
+ * When assembling for 64-bit (X86_64 defined) the RA..RSP macros map to
+ * the appropriate 64-bit registers.  Otherwise they expand to their 32-bit
+ * counterparts for i686 code.  Additional 8-bit aliases are provided for
+ * convenience and are identical in both modes.
+ */
 
 .ifdef X86_64
     .set RA, %rax
@@ -19,3 +26,8 @@
     .set RBP, %ebp
     .set RSP, %esp
 .endif
+
+.set AL, %al
+.set BL, %bl
+.set CL, %cl
+.set DL, %dl

--- a/bcplkit-0.9.7/src/rt.s
+++ b/bcplkit-0.9.7/src/rt.s
@@ -3,6 +3,7 @@
 // $Id: rt.s,v 1.7 2004/12/21 13:52:18 rn Exp $
 
 // BCPL compiler runtime
+// Uses register aliases defined in regs.inc
 
                 .include "sys_defs.inc"
 

--- a/bcplkit-0.9.7/src/su.s
+++ b/bcplkit-0.9.7/src/su.s
@@ -2,7 +2,7 @@
 
 // $Id: su.s,v 1.7 2004/12/18 17:51:16 rn Exp $
 
-                .include "sys_defs.inc"
+                .include "sys_defs.inc" // brings in register aliases
 
                 .set STACKBASE,54
                 .set STACKEND,55
@@ -25,12 +25,12 @@ _start:         cld
                 mov (RB),RSI
                 jmp start.3
 //
-start.1:        mov $' ',%al
+start.1:        mov $' ',AL
 start.2:        cmp RC,RDI
                 je start.4
                 stosb
 start.3:        lodsb
-                test %al,%al
+                test AL,AL
                 jnz start.2
                 add $8,RB
                 mov (RB),RSI

--- a/bcplkit-0.9.7/src/sys_freebsd.s
+++ b/bcplkit-0.9.7/src/sys_freebsd.s
@@ -2,6 +2,7 @@
 
 // BCPL compiler runtime
 // System interface: FreeBSD
+// Uses register aliases defined in regs.inc
 
                 .include "sys_defs.inc"
 

--- a/bcplkit-0.9.7/src/sys_linux.s
+++ b/bcplkit-0.9.7/src/sys_linux.s
@@ -2,6 +2,7 @@
 
 // BCPL compiler runtime
 // System interface: Linux
+// Uses register aliases defined in regs.inc
 
                 .include "sys_defs.inc"
 


### PR DESCRIPTION
## Summary
- introduce `AL`/`BL`/`CL`/`DL` macros and document register aliases
- clarify use of register macros in startup/OS assembly
- use the new `AL` macro in `su.s`

## Testing
- `as --32 -o /tmp/test32.o test.s`
- `as --64 -o /tmp/test64.o test.s`