### PR TITLE
Add self-test and bootstrap verification

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -27,6 +27,19 @@ The script picks `sys_linux.s`, `sys_freebsd.s` or `sys_linux64.s` based
 on the host platform.  You can also create the `src/sys.s` link manually
 and run `make` inside the `src` directory.
 
+Self-hosting and tests
+---------------------
+
+After a successful build you can verify the compiler by running its test
+suite and then rebuilding the sources with the freshly built compiler.
+
+```sh
+./makeall test       # build and run util/cmpltest
+./makeall bootstrap  # recompile the compiler and compare binaries
+```
+
+Both targets exit with a non-zero status if a failure occurs.
+
 Missing components
 ------------------
 

--- a/bcplkit-0.9.7/makeall
+++ b/bcplkit-0.9.7/makeall
@@ -56,15 +56,18 @@ for dir in ${DIRS}; do
 done
 
 if [ "$target" = "test" ]; then
+    echo "Running compiler test suite..."
     (cd util && ${MAKE} BCPL=../src/bcpl cmpltest)
     (cd util && ./cmpltest > cmpltest.out)
     grep -q '0 FAILURE(S)' util/cmpltest.out || {
         echo "cmpltest failed" 1>&2
         exit 1
     }
+    echo "cmpltest passed"
 fi
 
 if [ "$target" = "bootstrap" ]; then
+    echo "Verifying self-hosted rebuild..."
     tmp=`mktemp -d`
     for f in st cg xg; do
         cp src/$f $tmp/$f
@@ -78,5 +81,6 @@ if [ "$target" = "bootstrap" ]; then
         }
     done
     rm -rf $tmp
+    echo "Bootstrap rebuild matches original binaries"
 fi
 


### PR DESCRIPTION
## Summary
- document optional testing and bootstrapping steps
- enhance `makeall` with informative messages for `test` and `bootstrap`

## Testing
- `sh bcplkit-0.9.7/makeall test` *(fails: ../src/bcpl: Permission denied)*