### PR TITLE
Add clang-tidy precommit config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: '-*,clang-analyzer-*'
+WarningsAsErrors: ''

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: clang-tidy-c
+        name: clang-tidy (C23)
+        entry: clang-tidy --extra-arg=-std=c23
+        language: system
+        types: [c]
+      - id: clang-tidy-cpp
+        name: clang-tidy (C++17)
+        entry: clang-tidy --extra-arg=-std=c++17
+        language: system
+        types: [cpp]

--- a/README.txt
+++ b/README.txt
@@ -57,3 +57,9 @@ Testing
 Run `tests/run_tests.sh` to build the BCPL toolchain and compile a small
 program in both 32- and 64-bit modes. Continuous integration performs
 the same steps on GitHub Actions.
+
+Code quality
+------------
+Run `pre-commit install` to set up git hooks for clang-tidy. The
+configuration checks C files with the C23 standard and any C++ sources
+with the C++17 standard.

--- a/setup.sh
+++ b/setup.sh
@@ -19,7 +19,7 @@ done
 apt-get update -y
 
 for pkg in \
-  build-essential gcc g++ clang lld llvm \
+  build-essential gcc g++ clang clang-tidy clang-tools lld llvm \
   clang-format uncrustify astyle editorconfig pre-commit \
   make bmake ninja-build cmake meson \
   autoconf automake libtool m4 gawk flex bison byacc \


### PR DESCRIPTION
## Summary
- add clang-tidy hooks via pre-commit
- document quality checks in README
- install clang-tidy in setup script

## Testing
- `./tests/run_tests.sh` *(fails: missing multilib toolchain)*