### PR TITLE
Add kernel spinlock/IRQ test harness

### DIFF
--- a/tests/build_kernel_test.sh
+++ b/tests/build_kernel_test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+DIR=$(dirname "$0")
+SRC="$DIR/spinlock_irq_test.c"
+OBJ="$DIR/spinlock_irq_test.o"
+INC="/lib/modules/$(uname -r)/build/include"
+set +e
+clang -std=c23 -D__KERNEL__ -DMODULE -I"$INC" -c "$SRC" -o "$OBJ" 2>"$DIR/spinlock_irq_test.log"
+status=$?
+if [ $status -ne 0 ]; then
+    cat "$DIR/spinlock_irq_test.log"
+    exit 1
+fi
+exit 0

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -3,3 +3,10 @@ set -e
 DIR=$(dirname "$0")
 "$DIR/build_and_compile.sh" 32
 "$DIR/build_and_compile.sh" 64
+
+if "$DIR/build_kernel_test.sh"; then
+    echo "Kernel-space tests PASS"
+else
+    echo "Kernel-space tests FAIL"
+    exit 1
+fi

--- a/tests/spinlock_irq_test.c
+++ b/tests/spinlock_irq_test.c
@@ -1,0 +1,48 @@
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/spinlock.h>
+#include <linux/interrupt.h>
+
+#define QUEUE_SIZE 4
+static spinlock_t test_lock;
+static int queue[QUEUE_SIZE];
+static int head, tail;
+static struct tasklet_struct test_tasklet;
+
+static void irq_handler(unsigned long data)
+{
+    unsigned long flags;
+    spin_lock_irqsave(&test_lock, flags);
+    if ((tail + 1) % QUEUE_SIZE == head) {
+        pr_info("IRQ queue overflow occurred\n");
+    } else {
+        queue[tail] = (int)data;
+        tail = (tail + 1) % QUEUE_SIZE;
+    }
+    spin_unlock_irqrestore(&test_lock, flags);
+}
+
+static int __init irq_spin_test_init(void)
+{
+    spin_lock_init(&test_lock);
+    head = tail = 0;
+    tasklet_init(&test_tasklet, irq_handler, 1);
+    tasklet_schedule(&test_tasklet);
+    tasklet_schedule(&test_tasklet); /* trigger overflow */
+    for (int i = 0; i < 1000; ++i) {
+        spin_lock(&test_lock);
+        spin_unlock(&test_lock);
+    }
+    pr_info("irq_spin_test loaded\n");
+    return 0;
+}
+
+static void __exit irq_spin_test_exit(void)
+{
+    tasklet_kill(&test_tasklet);
+    pr_info("irq_spin_test unloaded\n");
+}
+
+module_init(irq_spin_test_init);
+module_exit(irq_spin_test_exit);
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
## Summary
- add a kernel-space test harness using a spinlock and a tasklet
- add a script to compile the kernel test with `clang -std=c23`
- extend `run_tests.sh` to build the new kernel test

## Testing
- `bash tests/run_tests.sh` *(fails: missing build dependencies)*
- `tests/build_kernel_test.sh` *(fails: `linux/init.h` not found)*