### PR TITLE
Add scheduler spinlock

### DIFF
--- a/releases/usr/sys/conf/mch.s
+++ b/releases/usr/sys/conf/mch.s
@@ -818,8 +818,27 @@ _cli:
 
 .globl	_sti
 _sti:
-	sti
-	ret
+        sti
+        ret
+
+.globl  _sched_lock_acquire
+_sched_lock_acquire:
+        mov     $_sched_lock, %edx
+1:
+        movl    $1, %eax
+        xchg    %eax,(%edx)
+        test    %eax,%eax
+        je      2f
+        pause
+        jmp     1b
+2:
+        ret
+
+.globl  _sched_lock_release
+_sched_lock_release:
+        mov     $_sched_lock, %edx
+        movl    $0,(%edx)
+        ret
 
 // Constants
 


### PR DESCRIPTION
## Summary
- introduce `sched_lock` for protecting the run queue
- guard run queue manipulation with the new spinlock
- provide assembly helpers for acquiring and releasing the lock

## Testing
- `./tests/run_tests.sh` *(fails: Makefile:30: missing separator)*