### PR TITLE
modernize spinlock header

### DIFF
--- a/releases/usr/sys/sys/sig.c
+++ b/releases/usr/sys/sys/sig.c
@@ -10,6 +10,7 @@
 #include "../h/reg.h"
 #include "../h/text.h"
 #include "../h/seg.h"
+#include <stdint.h>
 
 /*
  * Priority for tracing
@@ -29,10 +30,10 @@
 struct
 {
         lock_t  ip_lock;
-        int     ip_owner;
-        int     ip_req;
-        int     *ip_addr;
-        int     ip_data;
+        int32_t ip_owner;
+        int32_t ip_req;
+        int32_t *ip_addr;
+        int32_t ip_data;
 } ipc;
 
 /*

--- a/src-headers/spinlock.h
+++ b/src-headers/spinlock.h
@@ -1,5 +1,4 @@
-#ifndef SPINLOCK_H
-#define SPINLOCK_H
+#pragma once
 
 #include <stdint.h>
 #include <stdalign.h>
@@ -28,7 +27,7 @@ static inline unsigned int detect_cache_line_size(void)
 #endif
 
 struct spinlock {
-    volatile int locked;
+    volatile uint32_t locked;
 } __attribute__((aligned(CACHE_LINE_SIZE)));
 
 static inline void spin_lock(struct spinlock *lock)
@@ -48,4 +47,3 @@ static inline void spin_unlock(struct spinlock *lock)
 }
 #endif
 
-#endif /* SPINLOCK_H */


### PR DESCRIPTION
## Summary
- replace include guards with `#pragma once`
- use `<stdint.h>` types for spinlock internals
- adjust `sig.c` for explicit integer sizes

## Testing
- `tests/run_tests.sh` *(fails: Makefile missing separator)*