### PR TITLE
Add pragma once and modernize headers

### DIFF
--- a/releases/usr/sys/h/acct.h
+++ b/releases/usr/sys/h/acct.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 /*

--- a/releases/usr/sys/h/buf.h
+++ b/releases/usr/sys/h/buf.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 /* Changes: Copyright (c) 1999 Robert Nordier. All rights reserved. */
 

--- a/releases/usr/sys/h/callo.h
+++ b/releases/usr/sys/h/callo.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 /*
@@ -14,6 +15,6 @@ struct	callo
 {
 	int	c_time;		/* incremental time */
 	caddr_t	c_arg;		/* argument to routine */
-	int	(*c_func)();	/* routine */
+	void (*c_func)(caddr_t);	/* routine */
 };
 struct	callo	callout[NCALL];

--- a/releases/usr/sys/h/conf.h
+++ b/releases/usr/sys/h/conf.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 /* Changes: Copyright (c) 1999 Robert Nordier. All rights reserved. */
 
@@ -12,9 +13,9 @@
  */
 extern struct bdevsw
 {
-	int	(*d_open)();
-	int	(*d_close)();
-	int	(*d_strategy)();
+	void (*d_open)(dev_t, int);
+	void (*d_close)(dev_t, int);
+	void (*d_strategy)(struct buf *);
 	struct buf *d_tab;
 } bdevsw[];
 
@@ -23,12 +24,12 @@ extern struct bdevsw
  */
 extern struct cdevsw
 {
-	int	(*d_open)();
-	int	(*d_close)();
-	int	(*d_read)();
-	int	(*d_write)();
-	int	(*d_ioctl)();
-	int	(*d_stop)();
+	void (*d_open)(dev_t, int);
+	void (*d_close)(dev_t, int);
+	void (*d_read)(dev_t);
+	void (*d_write)(dev_t);
+	void (*d_ioctl)(dev_t, int, caddr_t, int);
+	void (*d_stop)(struct tty *);
 	struct tty *d_ttys;
 } cdevsw[];
 
@@ -37,14 +38,14 @@ extern struct cdevsw
  */
 extern struct linesw
 {
-	int	(*l_open)();
-	int	(*l_close)();
-	int	(*l_read)();
-	int	(*l_write)();
-	int	(*l_ioctl)();
-	int	(*l_rint)();
-	int	(*l_rend)();
-	int	(*l_meta)();
-	int	(*l_start)();
-	int	(*l_modem)();
+	int (*l_open)(dev_t, struct tty *, caddr_t);
+	int (*l_close)(struct tty *);
+	int (*l_read)(struct tty *);
+	caddr_t (*l_write)(struct tty *);
+	int (*l_ioctl)(int, struct tty *, caddr_t);
+	int (*l_rint)(int, struct tty *);
+	int (*l_rend)(struct tty *);
+	int (*l_meta)(struct tty *, int);
+	void (*l_start)(struct tty *);
+	int (*l_modem)(struct tty *, int);
 } linesw[];

--- a/releases/usr/sys/h/dir.h
+++ b/releases/usr/sys/h/dir.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 #ifndef	DIRSIZ

--- a/releases/usr/sys/h/fblk.h
+++ b/releases/usr/sys/h/fblk.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 struct fblk

--- a/releases/usr/sys/h/file.h
+++ b/releases/usr/sys/h/file.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 /*

--- a/releases/usr/sys/h/filsys.h
+++ b/releases/usr/sys/h/filsys.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 /*

--- a/releases/usr/sys/h/ino.h
+++ b/releases/usr/sys/h/ino.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 /*

--- a/releases/usr/sys/h/inode.h
+++ b/releases/usr/sys/h/inode.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 /* Changes: Copyright (c) 1999 Robert Nordier. All rights reserved. */
 

--- a/releases/usr/sys/h/map.h
+++ b/releases/usr/sys/h/map.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 struct map

--- a/releases/usr/sys/h/mount.h
+++ b/releases/usr/sys/h/mount.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 /*

--- a/releases/usr/sys/h/mpx.h
+++ b/releases/usr/sys/h/mpx.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 #define	M	3

--- a/releases/usr/sys/h/mx.h
+++ b/releases/usr/sys/h/mx.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 #define	NGROUPS		10	/* number of mpx files permitted at one time */

--- a/releases/usr/sys/h/param.h
+++ b/releases/usr/sys/h/param.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 /* Changes: Copyright (c) 1999 Robert Nordier. All rights reserved. */
 

--- a/releases/usr/sys/h/part.h
+++ b/releases/usr/sys/h/part.h
@@ -1,3 +1,4 @@
+#pragma once
 /* V7/x86 source code: see www.nordier.com/v7x86 for details. */
 /* Copyright (c) 2006 Robert Nordier.  All rights reserved. */
 

--- a/releases/usr/sys/h/pk.h
+++ b/releases/usr/sys/h/pk.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 /*

--- a/releases/usr/sys/h/prim.h
+++ b/releases/usr/sys/h/prim.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 #define	NOSLEEP	0400
@@ -8,4 +9,4 @@
 
 int	bwaiting,wcount;
 
-char *getepack();
+char *getepack(void);

--- a/releases/usr/sys/h/proc.h
+++ b/releases/usr/sys/h/proc.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 /*

--- a/releases/usr/sys/h/reg.h
+++ b/releases/usr/sys/h/reg.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 /* Changes: Copyright (c) 1999 Robert Nordier. All rights reserved. */
 

--- a/releases/usr/sys/h/seg.h
+++ b/releases/usr/sys/h/seg.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 /* Changes: Copyright (c) 1999 Robert Nordier. All rights reserved. */
 

--- a/releases/usr/sys/h/spinlock.h
+++ b/releases/usr/sys/h/spinlock.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef _SPINLOCK_H_
 #define _SPINLOCK_H_
 

--- a/releases/usr/sys/h/stat.h
+++ b/releases/usr/sys/h/stat.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 struct	stat

--- a/releases/usr/sys/h/systm.h
+++ b/releases/usr/sys/h/systm.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 /*
@@ -47,22 +48,22 @@ dev_t	pipedev;		/* pipe device */
 extern	int	icode[];	/* user init code */
 extern	int	szicode;	/* its size */
 
-dev_t getmdev();
-daddr_t	bmap();
-struct inode *ialloc();
-struct inode *iget();
-struct inode *owner();
-struct inode *maknode();
-struct inode *namei();
-struct buf *alloc();
-struct buf *getblk();
-struct buf *geteblk();
-struct buf *bread();
-struct buf *breada();
-struct filsys *getfs();
-struct file *getf();
-struct file *falloc();
-int	uchar();
+dev_t getmdev(void);
+daddr_t bmap(struct inode *, daddr_t, int);
+struct inode *ialloc(dev_t);
+struct inode *iget(dev_t, ino_t);
+struct inode *owner(void);
+struct inode *maknode(int);
+struct inode *namei(int (*)(void), int);
+struct buf *alloc(dev_t);
+struct buf *getblk(dev_t, daddr_t);
+struct buf *geteblk(void);
+struct buf *bread(dev_t, daddr_t);
+struct buf *breada(dev_t, daddr_t, daddr_t);
+struct filsys *getfs(dev_t);
+struct file *getf(int);
+struct file *falloc(void);
+int uchar(void);
 /*
  * Instrumentation
  */
@@ -79,5 +80,5 @@ long	tk_nout;
 extern struct sysent {
 	char	sy_narg;		/* total number of arguments */
 	char	sy_nrarg;		/* number of args in registers */
-	int	(*sy_call)();		/* handler */
+	void (*sy_call)(void);		/* handler */
 } sysent[];

--- a/releases/usr/sys/h/text.h
+++ b/releases/usr/sys/h/text.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 /*

--- a/releases/usr/sys/h/timeb.h
+++ b/releases/usr/sys/h/timeb.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 
 /*

--- a/releases/usr/sys/h/tty.h
+++ b/releases/usr/sys/h/tty.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 /* Changes: Copyright (c) 1999 Robert Nordier. All rights reserved. */
 
@@ -47,8 +48,8 @@ struct tty
 	struct	clist t_rawq;	/* input chars right off device */
 	struct	clist t_canq;	/* input chars after erase and kill */
 	struct	clist t_outq;	/* output list to device */
-	int	(* t_oproc)();	/* routine to start output */
-	int	(* t_iproc)();	/* routine to start input */
+	void (* t_oproc)(struct tty *);	/* routine to start output */
+	void (* t_iproc)(struct tty *);	/* routine to start input */
 	struct chan *t_chan;	/* destination channel */
 	caddr_t	t_linep;	/* aux line discipline pointer */
 	caddr_t	t_addr;		/* device address */

--- a/releases/usr/sys/h/types.h
+++ b/releases/usr/sys/h/types.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 /* Changes: Copyright (c) 1999 Robert Nordier. All rights reserved. */
 

--- a/releases/usr/sys/h/user.h
+++ b/releases/usr/sys/h/user.h
@@ -1,3 +1,4 @@
+#pragma once
 /* UNIX V7 source code: see /COPYRIGHT or www.tuhs.org for details. */
 /* Changes: Copyright (c) 1999 Robert Nordier. All rights reserved. */
 

--- a/src-headers/spinlock.h
+++ b/src-headers/spinlock.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef SPINLOCK_H
 #define SPINLOCK_H
 


### PR DESCRIPTION
## Summary
- apply `#pragma once` to kernel headers
- modernize function prototypes
- use explicit `void` parameter lists

## Testing
- `tests/run_tests.sh` *(fails: missing separator)*