### PR TITLE
Add Cap'n Proto helper library and demo

### DIFF
--- a/releases/usr/bin/buildall
+++ b/releases/usr/bin/buildall
@@ -84,6 +84,13 @@ cd /usr/src/libmp
 ./compall; ./mklib; cp libmp.a /usr/lib
 rm libmp.a *.o
 
+echo "== libcapnp_helpers =="
+cd /usr/src/libcapnp_helpers
+make
+cp libcapnp_helpers.a /usr/lib
+cp helpers.h /usr/include
+rm libcapnp_helpers.a *.o
+
 echo "== games =="
 cd /usr/src/games
 for i in arithmetic backgammon fish fortune hangman quiz wump

--- a/releases/usr/src/cmd/capnpdemo/README.md
+++ b/releases/usr/src/cmd/capnpdemo/README.md
@@ -1,0 +1,3 @@
+This example demonstrates using the `libcapnp_helpers` library. It defines a
+simple `Person` schema and serializes an instance to disk, then reads it back and
+prints the fields.

--- a/releases/usr/src/cmd/capnpdemo/demo.cpp
+++ b/releases/usr/src/cmd/capnpdemo/demo.cpp
@@ -1,0 +1,29 @@
+#include <capnp/schema-parser.h>
+#include <capnp/dynamic.h>
+#include <iostream>
+#include "../libcapnp_helpers/helpers.h"
+
+static const char PERSON_SCHEMA[] = R"(
+struct Person {
+  id @0 :UInt32;
+  name @1 :Text;
+}
+)";
+
+int main() {
+    capnp::SchemaParser parser;
+    auto schema = parser.parseFromString(PERSON_SCHEMA).getNested("Person");
+
+    capnp::MallocMessageBuilder message;
+    auto person = message.initRoot<capnp::DynamicStruct>(schema);
+    person.set("id", 42);
+    person.set("name", "Alice");
+
+    capnp_helpers::writeMessageToFile(message, "person.bin");
+
+    auto loaded = capnp_helpers::readMessageFromFile(schema, "person.bin");
+    auto loadedPerson = loaded.getRoot<capnp::DynamicStruct>(schema);
+    std::cout << "id=" << loadedPerson.get("id").as<uint32_t>()
+              << " name=" << loadedPerson.get("name").as<kj::StringPtr>() << std::endl;
+    return 0;
+}

--- a/releases/usr/src/cmd/capnpdemo/example.capnp
+++ b/releases/usr/src/cmd/capnpdemo/example.capnp
@@ -1,0 +1,5 @@
+@0xbf5147c8cf6daa0a;
+struct Person {
+  id @0 :UInt32;
+  name @1 :Text;
+}

--- a/releases/usr/src/cmd/capnpdemo/makefile
+++ b/releases/usr/src/cmd/capnpdemo/makefile
@@ -1,0 +1,20 @@
+CXXFLAGS=-O2 -std=c++20
+LDLIBS=-lcapnp_helpers -lcapnp -lkj
+
+all: capnpdemo
+
+capnpdemo: demo.o example.capnp
+capnp compile -oc++ example.capnp
+$(CXX) $(CXXFLAGS) -c demo.cpp
+$(CXX) $(CXXFLAGS) -o capnpdemo demo.o $(LDLIBS)
+
+cp: all
+cp capnpdemo /bin/capnpdemo
+rm -f capnpdemo demo.o example.capnp.c++ example.capnp.h
+
+cmp: all
+cmp capnpdemo /bin/capnpdemo
+rm -f capnpdemo demo.o example.capnp.c++ example.capnp.h
+
+clean:
+rm -f capnpdemo demo.o example.capnp.c++ example.capnp.h

--- a/releases/usr/src/cmd/makeall
+++ b/releases/usr/src/cmd/makeall
@@ -35,4 +35,5 @@ esac
 (echo ==== troff =====; cd troff; make $arg)
 (echo ==== uucp =====; cd uucp; make $arg)
 (echo ==== xsend =====; cd xsend; make $arg)
+(echo ==== capnpdemo =====; cd capnpdemo; make $arg)
 (echo ==== yacc =====; cd yacc; make $arg)

--- a/releases/usr/src/libcapnp_helpers/Makefile
+++ b/releases/usr/src/libcapnp_helpers/Makefile
@@ -1,0 +1,13 @@
+CXXFLAGS?=-O2 -std=c++20
+AR?=ar
+
+OBJS=helpers.o
+
+all: libcapnp_helpers.a
+
+libcapnp_helpers.a: $(OBJS)
+$(AR) rc $@ $(OBJS)
+ranlib $@
+
+clean:
+rm -f $(OBJS) libcapnp_helpers.a

--- a/releases/usr/src/libcapnp_helpers/README.md
+++ b/releases/usr/src/libcapnp_helpers/README.md
@@ -1,0 +1,8 @@
+This directory provides a small helper library wrapping basic Cap'n Proto
+file serialization. `helpers.h` declares two functions:
+
+- `writeMessageToFile()` writes a packed message to disk.
+- `readMessageFromFile()` reads a packed message back using a schema.
+
+A simple `Makefile` builds `libcapnp_helpers.a` which can be linked with
+user programs.

--- a/releases/usr/src/libcapnp_helpers/helpers.cpp
+++ b/releases/usr/src/libcapnp_helpers/helpers.cpp
@@ -1,0 +1,28 @@
+#include "helpers.h"
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdexcept>
+
+namespace capnp_helpers {
+
+void writeMessageToFile(::capnp::MessageBuilder& builder, const std::string& path) {
+    int fd = open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) throw std::runtime_error("open failed");
+    ::capnp::writePackedMessageToFd(fd, builder);
+    close(fd);
+}
+
+::capnp::MallocMessageBuilder readMessageFromFile(const ::capnp::StructSchema& schema,
+                                                  const std::string& path) {
+    int fd = open(path.c_str(), O_RDONLY);
+    if (fd < 0) throw std::runtime_error("open failed");
+    ::capnp::PackedFdMessageReader reader(fd);
+    ::capnp::MallocMessageBuilder builder;
+    auto dst = builder.initRoot<capnp::DynamicStruct>(schema);
+    auto src = reader.getRoot<capnp::DynamicStruct>(schema);
+    dst.copyFrom(src);
+    close(fd);
+    return builder;
+}
+
+} // namespace capnp_helpers

--- a/releases/usr/src/libcapnp_helpers/helpers.h
+++ b/releases/usr/src/libcapnp_helpers/helpers.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <capnp/dynamic.h>
+#include <capnp/serialize-packed.h>
+#include <string>
+
+namespace capnp_helpers {
+
+void writeMessageToFile(::capnp::MessageBuilder& builder, const std::string& path);
+::capnp::MallocMessageBuilder readMessageFromFile(const ::capnp::StructSchema& schema,
+                                                  const std::string& path);
+
+} // namespace capnp_helpers


### PR DESCRIPTION
## Summary
- add libcapnp_helpers with basic Cap'n Proto file helpers
- compile and install the helper library in `buildall`
- add a Cap'n Proto demo program built via `cmd/makeall`

## Testing
- `./tests/run_tests.sh` *(fails: Makefile:30: missing separator)*