### PR TITLE
Add mailbox feature tests

### DIFF
--- a/tests/build_and_compile.sh
+++ b/tests/build_and_compile.sh
@@ -1,8 +1,15 @@
 #!/bin/sh
 set -e
 BITS=$1
+shift
 DIR=$(cd "$(dirname "$0")"/.. && pwd)
 cd "$DIR/bcplkit-0.9.7"
 make -C src clean
 BITS=$BITS sh makeall all
-BCPLKITDIR=src/build/$BITS ./src/bcpl "$DIR/tests/hello.b"
+BCPLKITDIR=src/build/$BITS
+if [ $# -eq 0 ]; then
+    set -- "$DIR/tests/hello.b"
+fi
+for prog in "$@"; do
+    BCPLKITDIR=$BCPLKITDIR sh ./src/bcpl "$prog"
+done

--- a/tests/mailbox.bh
+++ b/tests/mailbox.bh
@@ -1,0 +1,32 @@
+GET "LIBHDR"
+
+MANIFEST $( MB_TIMEOUT = -1 $)
+
+LET CreateMailbox(size) = VALOF
+$( LET mb = VEC (size + 4)
+   mb!0 := size
+   mb!1 := 0
+   mb!2 := 0
+   mb!3 := 0
+   RESULTIS mb
+$)
+
+AND SendMessage(mb, msg) = VALOF
+$( IF mb!1 >= mb!0 RESULTIS 0
+   LET t = mb!3
+   mb!(4+t) := msg
+   mb!3 := (t + 1) REM mb!0
+   mb!1 := mb!1 + 1
+   RESULTIS 1
+$)
+
+AND ReceiveMessage(mb, timeout) = VALOF
+$( LET t = timeout
+   WHILE mb!1 = 0 & t > 0 DO t := t - 1
+   IF mb!1 = 0 RESULTIS MB_TIMEOUT
+   LET h = mb!2
+   LET msg = mb!(4+h)
+   mb!2 := (h + 1) REM mb!0
+   mb!1 := mb!1 - 1
+   RESULTIS msg
+$)

--- a/tests/mailbox_basic.b
+++ b/tests/mailbox_basic.b
@@ -1,0 +1,12 @@
+GET "LIBHDR"
+GET "mailbox.bh"
+
+LET START() = VALOF
+$( LET mb = CreateMailbox(4)
+   SendMessage(mb, 10)
+   SendMessage(mb, 20)
+   LET m1 = ReceiveMessage(mb, 1)
+   LET m2 = ReceiveMessage(mb, 1)
+   WRITEF("basic %N %N*N", m1, m2)
+   RESULTIS 0
+$)

--- a/tests/mailbox_overflow.b
+++ b/tests/mailbox_overflow.b
@@ -1,0 +1,14 @@
+GET "LIBHDR"
+GET "mailbox.bh"
+
+LET START() = VALOF
+$( LET mb = CreateMailbox(2)
+   FOR I = 1 TO 3 DO
+       IF SendMessage(mb, I)
+         THEN WRITEF("sent %N*N", I)
+         ELSE WRITEF("overflow %N*N", I)
+   FOR I = 1 TO 2 DO
+       LET msg = ReceiveMessage(mb, 1)
+       WRITEF("recv %N*N", msg)
+   RESULTIS 0
+$)

--- a/tests/mailbox_timeout.b
+++ b/tests/mailbox_timeout.b
@@ -1,0 +1,11 @@
+GET "LIBHDR"
+GET "mailbox.bh"
+
+LET START() = VALOF
+$( LET mb = CreateMailbox(1)
+   LET r = ReceiveMessage(mb, 2)
+   IF r = MB_TIMEOUT
+        THEN WRITEF("timeout*N")
+        ELSE WRITEF("recv %N*N", r)
+   RESULTIS 0
+$)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
 DIR=$(dirname "$0")
-"$DIR/build_and_compile.sh" 32
-"$DIR/build_and_compile.sh" 64
+PROGS="$DIR/hello.b $DIR/mailbox_basic.b $DIR/mailbox_overflow.b $DIR/mailbox_timeout.b"
+"$DIR/build_and_compile.sh" 32 $PROGS
+"$DIR/build_and_compile.sh" 64 $PROGS


### PR DESCRIPTION
## Summary
- extend `build_and_compile.sh` to accept multiple programs
- add simple mailbox implementation and three test programs
- compile new tests via `run_tests.sh`

## Testing
- `./tests/run_tests.sh` *(fails: cannot compile 32-bit bcplkit)*