### PR TITLE
Introduce IPC status enum

### DIFF
--- a/releases/usr/sys/sys/sig.c
+++ b/releases/usr/sys/sys/sig.c
@@ -25,6 +25,7 @@
  * per user.
  */
 #include "../h/spinlock.h"
+#include "../../../../src-headers/ipc_status.h"
 
 struct
 {
@@ -117,8 +118,9 @@ loop:
 			wakeup((caddr_t)pp);
 			cp->p_stat = SSTOP;
 			swtch();
-			if ((cp->p_flag&STRC)==0 || procxmt())
-				return;
+                        if ((cp->p_flag&STRC)==0 ||
+                            procxmt() == IPC_STATUS_CONTINUE)
+                                return;
 			goto loop;
 		}
 	exit(fsig(u.u_procp));
@@ -328,6 +330,7 @@ ptrace()
  * executes to implement the command
  * of the parent process in tracing.
  */
+ipc_status_t
 procxmt()
 {
         register int i;
@@ -335,7 +338,7 @@ procxmt()
         register struct text *xp;
 
         if (ipc.ip_owner != u.u_procp->p_pid)
-                return(0);
+                return IPC_STATUS_ERROR;
 	i = ipc.ip_req;
 	ipc.ip_req = 0;
 	wakeup((caddr_t)&ipc);
@@ -415,7 +418,7 @@ procxmt()
 		u.u_procp->p_sig = 0;
 		if (ipc.ip_data)
 			psignal(u.u_procp, ipc.ip_data);
-		return(1);
+                return IPC_STATUS_CONTINUE;
 
 	/* force exit */
 	case 8:
@@ -423,7 +426,8 @@ procxmt()
 
 	default:
 	error:
-		ipc.ip_req = -1;
-	}
-	return(0);
+                ipc.ip_req = -1;
+                return IPC_STATUS_ERROR;
+        }
+        return IPC_STATUS_OK;
 }

--- a/src-headers/ipc_status.h
+++ b/src-headers/ipc_status.h
@@ -1,0 +1,18 @@
+#ifndef IPC_STATUS_H
+#define IPC_STATUS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    IPC_STATUS_SUCCESS = 0,
+    IPC_STATUS_CONTINUE = 1,
+    IPC_STATUS_ERROR = -1
+} ipc_status_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* IPC_STATUS_H */


### PR DESCRIPTION
## Summary
- add new `ipc_status.h` with enumeration for IPC return values
- update `sig.c` tracing routines to use `ipc_status_t`

## Testing
- `BITS=64 sh makeall all` *(fails: `../build/64/icint.o` error)*
- `./tests/run_tests.sh` *(fails: Permission denied running bcpl)*
