### PR TITLE
Implement simple IPC mailboxes

### DIFF
--- a/src-kernel/Makefile
+++ b/src-kernel/Makefile
@@ -1,0 +1,23 @@
+CC ?= cc
+CFLAGS ?= -std=c23 -O2
+CFLAGS += -I../src-headers -m$(BITS)
+
+OBJDIR ?= build/$(BITS)
+LIB := $(OBJDIR)/libkernel.a
+
+SRCS := ipc/mailbox.c ipc/exo.c
+OBJS := $(SRCS:%=$(OBJDIR)/%)
+
+all: $(LIB)
+
+$(OBJDIR)/%.o: %.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(LIB): $(OBJS)
+	ar rcs $@ $^
+
+clean:
+	rm -rf build
+
+.PHONY: all clean

--- a/src-kernel/ipc/exo.c
+++ b/src-kernel/ipc/exo.c
@@ -1,0 +1,11 @@
+#include "mailbox.h"
+
+int exo_send(struct exo_proc *proc, const void *data, size_t len)
+{
+    return mailbox_enqueue(&proc->mbox, data, len);
+}
+
+ssize_t exo_recv(struct exo_proc *proc, void *buf, size_t len)
+{
+    return mailbox_dequeue(&proc->mbox, buf, len);
+}

--- a/src-kernel/ipc/mailbox.c
+++ b/src-kernel/ipc/mailbox.c
@@ -1,0 +1,48 @@
+#include "mailbox.h"
+#include <stdlib.h>
+#include <string.h>
+
+void mailbox_init(struct mailbox *mb)
+{
+    mb->head = mb->tail = NULL;
+    mb->lock.locked = 0;
+}
+
+int mailbox_enqueue(struct mailbox *mb, const void *data, size_t len)
+{
+    struct mailbox_msg *m = malloc(sizeof(*m) + len);
+    if (!m)
+        return -1;
+    m->next = NULL;
+    m->len = len;
+    memcpy(m->data, data, len);
+
+    spin_lock(&mb->lock);
+    if (!mb->tail) {
+        mb->head = mb->tail = m;
+    } else {
+        mb->tail->next = m;
+        mb->tail = m;
+    }
+    spin_unlock(&mb->lock);
+    return 0;
+}
+
+ssize_t mailbox_dequeue(struct mailbox *mb, void *buf, size_t len)
+{
+    spin_lock(&mb->lock);
+    struct mailbox_msg *m = mb->head;
+    if (!m) {
+        spin_unlock(&mb->lock);
+        return -1;
+    }
+    mb->head = m->next;
+    if (!mb->head)
+        mb->tail = NULL;
+    spin_unlock(&mb->lock);
+
+    size_t copy_len = len < m->len ? len : m->len;
+    memcpy(buf, m->data, copy_len);
+    free(m);
+    return copy_len;
+}

--- a/src-kernel/ipc/mailbox.h
+++ b/src-kernel/ipc/mailbox.h
@@ -1,0 +1,39 @@
+#ifndef MAILBOX_H
+#define MAILBOX_H
+
+#include <stddef.h>
+#include <sys/types.h>
+#include "../../src-headers/spinlock.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct mailbox_msg {
+    struct mailbox_msg *next;
+    size_t len;
+    char data[];
+};
+
+struct mailbox {
+    struct mailbox_msg *head;
+    struct mailbox_msg *tail;
+    struct spinlock lock;
+};
+
+void mailbox_init(struct mailbox *mb);
+int mailbox_enqueue(struct mailbox *mb, const void *data, size_t len);
+ssize_t mailbox_dequeue(struct mailbox *mb, void *buf, size_t len);
+
+struct exo_proc {
+    struct mailbox mbox;
+};
+
+int exo_send(struct exo_proc *proc, const void *data, size_t len);
+ssize_t exo_recv(struct exo_proc *proc, void *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MAILBOX_H */

--- a/tests/build_and_compile.sh
+++ b/tests/build_and_compile.sh
@@ -6,3 +6,6 @@ cd "$DIR/bcplkit-0.9.7"
 make -C src clean
 BITS=$BITS sh makeall all
 BCPLKITDIR=src/build/$BITS ./src/bcpl "$DIR/tests/hello.b"
+cd "$DIR/src-kernel"
+make clean
+BITS=$BITS make


### PR DESCRIPTION
## Summary
- add kernel IPC mailbox implementation
- create wrappers `exo_send` and `exo_recv`
- compile new kernel sources in tests

## Testing
- `./tests/run_tests.sh` *(fails: `Syntax error: end of file unexpected`)*